### PR TITLE
strategies: set max stop loss

### DIFF
--- a/strategies/trend-follow/BollingerBandTrendFollow/scripts/BollingerBandTrendFollowStrategy.cs
+++ b/strategies/trend-follow/BollingerBandTrendFollow/scripts/BollingerBandTrendFollowStrategy.cs
@@ -78,6 +78,9 @@ namespace cAlgo.Robots
             // Trade amount
             double qty = ((RiskPercentage/100) * Account.Balance) / (AtrMultiplier * Indicators.AverageTrueRange(AtrLength, MovingAverageType.Simple).Result.LastValue);
             double qtyInLots = ((int)(qty /Symbol.VolumeInUnitsStep)) * Symbol.VolumeInUnitsStep;
+
+            double maxStopLoss = (upperBand-lowerBand) * 3;
+            double maxStopLossInPips = maxStopLoss / Symbol.PipValue;
             
             bool buyCondition = lastClosePrice > upperBand && !isOpenPosition && filter;
             bool sellCondition = lastClosePrice < lowerBand && isOpenPosition;
@@ -90,7 +93,7 @@ namespace cAlgo.Robots
             // Entry
             if(buyCondition)
             {
-                ExecuteMarketOrder(TradeType.Buy, SymbolName, qtyInLots, label);
+                ExecuteMarketOrder(TradeType.Buy, SymbolName, qtyInLots, label, maxStopLossInPips, null);
             }
             
             // Exit

--- a/strategies/trend-follow/KeltnerChannelTrendFollow/scripts/KeltnerChannelTrendFollowStrategy.cs
+++ b/strategies/trend-follow/KeltnerChannelTrendFollow/scripts/KeltnerChannelTrendFollowStrategy.cs
@@ -55,7 +55,7 @@ namespace cAlgo.Robots
             // Perform calculations and analysis
             // **********************************
 
-            // Initialize indicators
+            // Basic
             ExponentialMovingAverage ema = Indicators.ExponentialMovingAverage(Bars.ClosePrices, EmaLength);
             AverageTrueRange atr = Indicators.AverageTrueRange(AtrBreakoutLength, MovingAverageType.Simple);
 
@@ -64,8 +64,12 @@ namespace cAlgo.Robots
 
             string label = $"KeltnerChannelTrendFollow_cBot-{Symbol.Name}";
 
+            // Trade amount
             double qty = ((RiskPercentage / 100) * Account.Balance) / (AtrMultiplier * Indicators.AverageTrueRange(AtrLength, MovingAverageType.Simple).Result.LastValue);
             double qtyInLots = ((int)(qty / Symbol.VolumeInUnitsStep)) * Symbol.VolumeInUnitsStep;
+            
+            double maxStopLoss = (upperChannel-lowerChannel) * 1.5;
+            double maxStopLossInPips = maxStopLoss / Symbol.PipValue;
 
             // Filter
             double lastClosePrice = Bars.ClosePrices.LastValue;
@@ -87,7 +91,7 @@ namespace cAlgo.Robots
             // ********************************
             if (buyCondition)
             {
-                ExecuteMarketOrder(TradeType.Buy, SymbolName, qtyInLots, label);
+                ExecuteMarketOrder(TradeType.Buy, SymbolName, qtyInLots, label, maxStopLossInPips, null);
             }
 
             if (sellCondition)

--- a/strategies/trend-follow/SuperTrendFollow/scripts/SuperTrendFollowStrategy.cs
+++ b/strategies/trend-follow/SuperTrendFollow/scripts/SuperTrendFollowStrategy.cs
@@ -73,6 +73,10 @@ namespace cAlgo.Robots
             double qty = ((RiskPercentage/100) * Account.Balance) / (AtrMultiplier * Indicators.AverageTrueRange(AtrLength, MovingAverageType.Simple).Result.LastValue);
             double qtyInLots = ((int)(qty /Symbol.VolumeInUnitsStep)) * Symbol.VolumeInUnitsStep;
             
+            double lowerChannel = Indicators.DonchianChannel(10).Bottom.LastValue;
+            double maxStopLoss = (lastClosePrice-lowerChannel) * 1.5;
+            double maxStopLossInPips = maxStopLoss / Symbol.PipValue;
+            
             bool buyCondition = isUpTrend && !isOpenPosition && filter;
             bool sellCondition = !isUpTrend && isOpenPosition;
             
@@ -83,7 +87,7 @@ namespace cAlgo.Robots
             // Entry
             if(buyCondition)
             {
-                ExecuteMarketOrder(TradeType.Buy, SymbolName, qtyInLots, label);
+                ExecuteMarketOrder(TradeType.Buy, SymbolName, qtyInLots, label, maxStopLossInPips, null);
             }
             
             // Exit

--- a/strategies/trend-follow/TurtleTrendFollow/scripts/TurtleTrendFollowStrategy.cs
+++ b/strategies/trend-follow/TurtleTrendFollow/scripts/TurtleTrendFollowStrategy.cs
@@ -61,6 +61,9 @@ namespace cAlgo.Robots
             double qty = ((RiskPercentage/100) * Account.Balance) / (AtrMultiplier * Indicators.AverageTrueRange(20,MovingAverageType.Simple).Result.LastValue);
             double qtyInLots = ((int)(qty /Symbol.VolumeInUnitsStep)) * Symbol.VolumeInUnitsStep;
             
+            double maxStopLoss = (upperChannel-lowerChannel) * 1.5;
+            double maxStopLossInPips = maxStopLoss / Symbol.PipValue;
+            
             // Filter
             bool priceAboveSMA = closePrice > Indicators.SimpleMovingAverage(Bars.ClosePrices, SmaLength).Result.LastValue;
             bool rsiAboveValue = Indicators.RelativeStrengthIndex(Bars.ClosePrices, 14).Result.LastValue > RsiValue;
@@ -79,7 +82,7 @@ namespace cAlgo.Robots
             // Entry
             if(buyCondition)
             {
-                ExecuteMarketOrder(TradeType.Buy, SymbolName, qtyInLots, label);
+                ExecuteMarketOrder(TradeType.Buy, SymbolName, qtyInLots, label, maxStopLossInPips, null);
             }
             
             // Exit
@@ -87,7 +90,7 @@ namespace cAlgo.Robots
             {
                 position.Close();
             }
-
+            
             Print("Sucessful call OnBarClosed() method.");
          }
     }


### PR DESCRIPTION
Added setting of max stop loss order if the market goes more than 1.5 upper - lower band.

Exception for bollinger band, here you need to set more than 3 upper - lower bands.